### PR TITLE
fix: change inheritance of the mastermind interaction dialog to compo…

### DIFF
--- a/src/tecrys/svc/SvcBasePlugin.kt
+++ b/src/tecrys/svc/SvcBasePlugin.kt
@@ -10,7 +10,6 @@ import com.fs.starfarer.api.combat.MissileAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.impl.campaign.ghosts.SensorGhostManager
 import com.thoughtworks.xstream.XStream
-import exerelin.campaign.SectorManager
 import org.dark.shaders.util.ShaderLib
 import org.magiclib.util.MagicSettings
 import tecrys.svc.colonycrisis.SymbioticCrisisCause

--- a/src/tecrys/svc/SvcCampaignPlugin.kt
+++ b/src/tecrys/svc/SvcCampaignPlugin.kt
@@ -5,7 +5,6 @@ import com.fs.starfarer.api.PluginPick
 import com.fs.starfarer.api.campaign.*
 import com.fs.starfarer.api.impl.campaign.ids.MemFlags
 import com.fs.starfarer.api.impl.campaign.ids.Tags
-import exerelin.console.commands.SpawnInvasionFleet.getFaction
 import tecrys.svc.industries.VoidlingHatchery
 import tecrys.svc.listeners.MastermindFleetListener
 import tecrys.svc.world.fleets.FleetManager


### PR DESCRIPTION
change inheritance of the mastermind interaction dialog to composition in order to hide the inheritance from other mods, meaning they won't mistakenly try to interact with it the same way they would with a vanilla FIDPI